### PR TITLE
Fix stale CASE exchange blocking new session handshake

### DIFF
--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -474,7 +474,10 @@ impl Session {
     }
 
     pub(crate) fn remove_exch(&mut self, index: usize) -> bool {
-        let exchange = unwrap!(self.exchanges[index].as_mut());
+        let Some(exchange) = self.exchanges[index].as_mut() else {
+            // Already removed (e.g. evicted by stale-exchange handling before Drop ran)
+            return true;
+        };
         let exchange_id = ExchangeId::new(self.id, index);
 
         if exchange.mrp.is_retrans_pending() {

--- a/rs-matter/src/transport/session.rs
+++ b/rs-matter/src/transport/session.rs
@@ -312,33 +312,38 @@ impl Session {
 
         let exch_index = self.get_exch_for_rx(&rx_header.proto);
         if let Some(exch_index) = exch_index {
-            let exch = unwrap!(self.exchanges[exch_index].as_mut());
-
-            exch.post_recv(&rx_header.plain, &rx_header.proto, epoch)?;
-
-            Ok(false)
-        } else {
-            if !rx_header.proto.is_initiator()
-                || !MessageMeta::from(&rx_header.proto).is_new_exchange()
-            {
-                // Do not create a new exchange if the peer is not an initiator, or if
-                // the packet is NOT a candidate for a new exchange
-                // (i.e. it is a standalone ACK or a SC status response)
-                Err(ErrorCode::NoExchange)?;
-            }
-
-            if let Some(exch_index) =
-                self.add_exch(rx_header.proto.exch_id, Role::Responder(Default::default()))
-            {
-                // unwrap is safe as we just created the exchange
+            // If we receive a new session request (CASESigma1/PBKDFParamRequest) on an
+            // existing exchange, the peer has restarted the handshake. Remove the stale
+            // exchange (or mark as dropped if MRP is pending) and create a fresh one.
+            if MessageMeta::from(&rx_header.proto).is_new_session() {
+                warn!("New session request on existing exchange — peer restarted handshake, evicting stale exchange");
+                self.remove_exch(exch_index);
+                // Fall through to create a new exchange below
+            } else {
                 let exch = unwrap!(self.exchanges[exch_index].as_mut());
 
                 exch.post_recv(&rx_header.plain, &rx_header.proto, epoch)?;
 
-                Ok(true)
-            } else {
-                Err(ErrorCode::NoSpaceExchanges)?
+                return Ok(false);
             }
+        }
+
+        // Create a new exchange for this message (new session request, or no existing exchange)
+        if !rx_header.proto.is_initiator() || !MessageMeta::from(&rx_header.proto).is_new_exchange()
+        {
+            Err(ErrorCode::NoExchange)?;
+        }
+
+        if let Some(exch_index) =
+            self.add_exch(rx_header.proto.exch_id, Role::Responder(Default::default()))
+        {
+            let exch = unwrap!(self.exchanges[exch_index].as_mut());
+
+            exch.post_recv(&rx_header.plain, &rx_header.proto, epoch)?;
+
+            Ok(true)
+        } else {
+            Err(ErrorCode::NoSpaceExchanges)?
         }
     }
 


### PR DESCRIPTION
## Problem

When a Matter client restarts and sends a new `CASESigma1` reusing the same exchange ID as an in-progress handshake, the old exchange is still awaiting `CASESigma3`. The new `Sigma1` gets routed to the stale exchange, producing:

```
Invalid opcode: CASESigma1, expected: CASESigma3
```

The handshake fails and the client must wait through its retry/backoff cycle (typically 30-60s) before succeeding with a different exchange ID.

This is easily reproducible by restarting a Matter controller that connects to an rs-matter server — the first reconnect attempt always fails.

## Fix

In `Session::post_recv()`, when an existing exchange receives a new session request (`CASESigma1` or `PBKDFParamRequest`), mark the stale exchange as `Dropped` and fall through to create a fresh one. The new handshake proceeds immediately from scratch.

Uses the existing `MessageMeta::is_new_session()` check and `Role::set_dropped_state()` — no new types or APIs needed.

## Testing

Tested with a Zigbee-to-Matter bridge (rs-matter server) and a Matter controller client (also rs-matter based). Before the fix, every server restart caused a 30-60s reconnect delay. After the fix, the client reconnects on its first attempt.