### PR TITLE
fix starved executor problem by making setup_verifier() async, and by

### DIFF
--- a/rs-matter/src/sc/pase/responder.rs
+++ b/rs-matter/src/sc/pase/responder.rs
@@ -23,7 +23,7 @@
 use rand_core::RngCore;
 
 use crate::crypto::{
-    CanonEcPointRef, Crypto, HmacHashRef, Kdf, AEAD_CANON_KEY_LEN, EC_POINT_ZEROED,
+    CanonEcPoint, CanonEcPointRef, Crypto, HmacHashRef, Kdf, AEAD_CANON_KEY_LEN, EC_POINT_ZEROED,
     HMAC_HASH_ZEROED,
 };
 use crate::dm::ChangeNotify;
@@ -194,9 +194,21 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
     async fn handle_pasepake1(&mut self, exchange: &mut Exchange<'_>) -> Result<(), Error> {
         check_opcode(exchange, OpCode::PASEPake1)?;
 
-        let req = get_root_node_struct(exchange.rx()?.payload())?;
-        let pake1 = Pake1::from_tlv(&req)?;
-        let a_pt: CanonEcPointRef<'_> = pake1.pa.0.try_into()?;
+        // Copy the EC point out of the RX buffer into an owned local variable,
+        // so we can release the RX buffer before the heavy SPAKE2+ crypto.
+        // This is critical on resource-constrained devices (e.g. ESP32-C6) where
+        // holding the RX buffer during long synchronous crypto operations starves
+        // the cooperative executor, preventing WiFi/BLE packet processing.
+        let a_pt_owned: CanonEcPoint = {
+            let req = get_root_node_struct(exchange.rx()?.payload())?;
+            let pake1 = Pake1::from_tlv(&req)?;
+            let a_pt: CanonEcPointRef<'_> = pake1.pa.0.try_into()?;
+            CanonEcPoint::from(a_pt)
+        };
+
+        // Release the RX buffer so the transport layer can receive new packets
+        // while we perform the expensive SPAKE2+ computation below.
+        exchange.rx_done()?;
 
         let mut b_pt = EC_POINT_ZEROED;
         let mut cb = HMAC_HASH_ZEROED;
@@ -205,22 +217,31 @@ impl<'a, C: Crypto> PaseResponder<'a, C> {
         let notify_change =
             |endpt_id, cluster_id, attr_id| self.notify.notify(endpt_id, cluster_id, attr_id);
 
-        let has_comm_window = {
+        // Clone the verifier data out of the state so we can call
+        // setup_verifier (which is async) outside the synchronous with_state closure.
+        let verifier_data = {
             exchange.with_state(|state| {
                 if let Some(comm_window) = state.pase.comm_window(notify_mdns, notify_change)? {
-                    self.spake2p.setup_verifier(
-                        &self.crypto,
-                        &comm_window.verifier,
-                        a_pt,
-                        &mut b_pt,
-                        &mut cb,
-                    )?;
-
-                    Ok(true)
+                    Ok(Some(comm_window.verifier.clone()))
                 } else {
-                    Ok(false)
+                    Ok(None)
                 }
             })?
+        };
+
+        let has_comm_window = if let Some(verifier_data) = &verifier_data {
+            self.spake2p
+                .setup_verifier(
+                    &self.crypto,
+                    verifier_data,
+                    a_pt_owned.reference(),
+                    &mut b_pt,
+                    &mut cb,
+                )
+                .await?;
+            true
+        } else {
+            false
         };
 
         if has_comm_window {

--- a/rs-matter/src/sc/pase/spake2p.rs
+++ b/rs-matter/src/sc/pase/spake2p.rs
@@ -242,7 +242,7 @@ impl Spake2P {
         context.finish(&mut self.context_hash)
     }
 
-    pub fn setup_verifier<C: Crypto>(
+    pub async fn setup_verifier<C: Crypto>(
         &mut self,
         crypto: C,
         verifier: &Spake2pVerifierData,
@@ -280,10 +280,14 @@ impl Spake2P {
             (crypto.ec_scalar(w0)?, crypto.ec_point(l_pt)?)
         };
 
+        embassy_futures::yield_now().await;
+
         let n_pt = crypto.ec_point(Self::MATTER_N_BIN)?;
         let (b_pt, xy) = Self::compute_b_pt_xy(&crypto, &n_pt, &w0)?;
 
         b_pt.write_canon(b_pt_out)?;
+
+        embassy_futures::yield_now().await;
 
         let mut tt_hash = HASH_ZEROED;
         Self::compute_verifier_tt_hash(
@@ -297,6 +301,8 @@ impl Spake2P {
             &xy,
             &mut tt_hash,
         )?;
+
+        embassy_futures::yield_now().await;
 
         Self::compute_ke_ca_cb(
             &crypto,
@@ -944,13 +950,13 @@ mod tests {
 
         let mut b_pt = CanonEcPoint::new();
         let mut cb_from_verifier = HmacHash::new();
-        unwrap!(verifier.setup_verifier(
+        unwrap!(embassy_futures::block_on(verifier.setup_verifier(
             test_only_crypto(),
             &verifier_data,
             a_pt.reference(),
             &mut b_pt,
             &mut cb_from_verifier
-        ));
+        )));
 
         // === PROVER SIDE (continued) ===
         // Step 3: Prover receives Y and cB, computes cA
@@ -1032,13 +1038,13 @@ mod tests {
 
         let mut b_pt = CanonEcPoint::new();
         let mut cb_from_verifier = HmacHash::new();
-        unwrap!(verifier.setup_verifier(
+        unwrap!(embassy_futures::block_on(verifier.setup_verifier(
             test_only_crypto(),
             &verifier_data,
             a_pt.reference(),
             &mut b_pt,
             &mut cb_from_verifier
-        ));
+        )));
 
         // Prover should fail to verify cB (wrong password means different cB)
         let mut ca_from_prover = HmacHash::new();


### PR DESCRIPTION
# Changes to rs-matter 

## Context
This is meant as the primary fix for https://github.com/project-chip/rs-matter/issues/409

## Problem

During the PASE (Passcode-Authenticated Session Establishment) handshake,
the `setup_verifier()` function in the SPAKE2+ implementation performs
multiple P-256 elliptic curve operations. On an ESP32-C6 (~160 MHz RISC-V
core, software-only ECC), these operations take roughly 300 ms to over 1
second in total.

Because the entire Matter stack runs as a single cooperative async task
(composed via `select`), this long synchronous computation has two
consequences:

1. **The transport layer's single RX buffer is held** for the full duration
   of the crypto, because the `RxMessage` (which wraps an `IfMutexGuard`)
   is not released until `send_with()` is called after `setup_verifier()`
   returns. No new packets can be received by the transport layer while
   this lock is held.

2. **No `.await` yield points exist** inside `setup_verifier()`, so the
   cooperative executor cannot poll any other future during the computation.
   This starves the WiFi driver (causing `RX QUEUE FULL` log spam), the BLE
   stack (risking connection supervision timeouts), mDNS, and the
   embassy-net IP stack.

## Changes

### `rs-matter/src/sc/pase/responder.rs` — release RX buffer before heavy crypto

In `handle_pasepake1()`:

- The peer's EC point (`a_pt`) is now **copied** out of the RX buffer into
  an owned `CanonEcPoint` before the heavy computation begins.
- `exchange.rx_done()` is called immediately after the copy, **releasing
  the RX buffer** so the transport layer can receive new packets as soon as
  the executor gets a chance to poll it.
- The verifier data is **cloned** out of the Matter state (via
  `with_state`) so that `setup_verifier()` — now an async function — can
  be called outside the synchronous `with_state` closure.

### `rs-matter/src/sc/pase/spake2p.rs` — make `setup_verifier` async with yield points

- `setup_verifier()` is changed from `pub fn` to `pub async fn`.
- Three `embassy_futures::yield_now().await` calls are inserted between the
  major computation steps:
  1. After extracting/deriving `w0` and `L` (initial key material).
  2. After `compute_b_pt_xy` and writing `b_pt` (double-scalar multiply).
  3. After `compute_verifier_tt_hash` (which includes `compute_zv_verifier`
     with its expensive EC operations).
- Each yield point allows the cooperative executor to briefly service WiFi,
  BLE, mDNS, and embassy-net before resuming the next crypto step.
- The two test callers (`test_prover_verifier_roundtrip` and
  `test_complete_prover_wrong_password`) are updated to wrap the now-async
  `setup_verifier()` call with `embassy_futures::block_on(...)`.

## Diff summary

```
 rs-matter/src/sc/pase/responder.rs | ~40 lines changed
 rs-matter/src/sc/pase/spake2p.rs   | ~20 lines changed
```
