### PR TITLE
fix: Windows support for examples (signal handling + mDNS interface s…

### DIFF
--- a/examples/src/bin/chip_tool_tests.rs
+++ b/examples/src/bin/chip_tool_tests.rs
@@ -248,8 +248,11 @@ fn main() -> Result<(), Error> {
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
     }
 
-    // Listen to SIGTERM because at the end of the test we'll receive it
+    // Listen to a termination signal: SIGTERM on Unix, SIGINT (Ctrl+C) on Windows
+    #[cfg(not(windows))]
     let mut term_signal = Signals::new([Signal::Term])?;
+    #[cfg(windows)]
+    let mut term_signal = Signals::new([Signal::Int])?;
     let mut term = pin!(async {
         term_signal.next().await;
         Ok(())

--- a/examples/src/bin/dimmable_light.rs
+++ b/examples/src/bin/dimmable_light.rs
@@ -229,8 +229,11 @@ fn run() -> Result<(), Error> {
         matter.open_basic_comm_window(MAX_COMM_WINDOW_TIMEOUT_SECS, &crypto, dm.change_notify())?;
     }
 
-    // Listen to SIGTERM because at the end of the test we'll receive it
+    // Listen to a termination signal (SIGTERM on Unix, SIGINT/Ctrl+C on Windows)
+    #[cfg(unix)]
     let mut term_signal = Signals::new([Signal::Term])?;
+    #[cfg(windows)]
+    let mut term_signal = Signals::new([Signal::Int])?;
     let mut term = pin!(async {
         term_signal.next().await;
         Ok(())

--- a/examples/src/common/mdns.rs
+++ b/examples/src/common/mdns.rs
@@ -82,27 +82,40 @@ async fn run_builtin_mdns<C: Crypto>(matter: &Matter<'_>, crypto: C) -> Result<(
         let all = if_addrs::get_if_addrs().map_err(|_| ErrorCode::StdIoError)?;
 
         // A quick and dirty way to pick the interface we want: find one that
-        // has both an IPv6 link-local address AND a non-loopback IPv4 address
-        // assigned. Most likely that's the "real" LAN interface we need, as
-        // opposed to all the docker/libvirt/virtual interfaces that might be
-        // present on the machine and which typically are IPv4-only.
-        let candidate = all
-            .iter()
-            .filter(|ia| !ia.is_loopback())
-            .filter_map(|ia| match ia.addr {
-                if_addrs::IfAddr::V6(ref v6) if (v6.ip.segments()[0] & 0xffc0) == 0xfe80 => {
-                    Some((ia.name.clone(), v6.ip, ia.index.unwrap_or(0)))
-                }
-                _ => None,
-            })
-            .find_map(|(iname, ipv6, index)| {
-                all.iter()
-                    .filter(|ia2| ia2.name == iname)
-                    .find_map(|ia2| match ia2.addr {
-                        if_addrs::IfAddr::V4(ref v4) => Some((iname.clone(), v4.ip, ipv6, index)),
-                        _ => None,
-                    })
-            })
+        // has both an IPv6 address AND a non-loopback IPv4 address assigned.
+        // Prefer link-local (fe80::/10) IPv6 addresses — most likely that's
+        // the "real" LAN interface we need, as opposed to all the
+        // docker/libvirt/virtual interfaces that might be present on the
+        // machine and which typically are IPv4-only.
+        //
+        // On Windows the `if_addrs` crate may omit link-local IPv6 addresses,
+        // so we fall back to accepting any non-loopback IPv6 address paired
+        // with an IPv4 address on the same interface.
+        let find_candidate = |ipv6_filter: fn(std::net::Ipv6Addr) -> bool| {
+            all.iter()
+                .filter(|ia| !ia.is_loopback())
+                .filter_map(|ia| match ia.addr {
+                    if_addrs::IfAddr::V6(ref v6) if ipv6_filter(v6.ip) => {
+                        Some((ia.name.clone(), v6.ip, ia.index.unwrap_or(0)))
+                    }
+                    _ => None,
+                })
+                .find_map(|(iname, ipv6, index)| {
+                    all.iter()
+                        .filter(|ia2| ia2.name == iname)
+                        .find_map(|ia2| match ia2.addr {
+                            if_addrs::IfAddr::V4(ref v4) => {
+                                Some((iname.clone(), v4.ip, ipv6, index))
+                            }
+                            _ => None,
+                        })
+                })
+        };
+
+        // Prefer an interface with a link-local IPv6 address …
+        let candidate = find_candidate(|ip| (ip.segments()[0] & 0xffc0) == 0xfe80)
+            // … otherwise accept any non-loopback IPv6 address
+            .or_else(|| find_candidate(|_| true))
             .ok_or_else(|| {
                 error!("Cannot find network interface suitable for mDNS broadcasting");
                 ErrorCode::StdIoError


### PR DESCRIPTION
Problem

The `dimmable_light` and `chip_tool_tests` examples crash immediately on Windows with:

```/dev/null/error.txt#L1
Error: Error::StdIoError: unsupported signal
```

This is caused by two Windows-incompatible assumptions in the example code.

## Changes

### 1. Signal handling (`dimmable_light.rs`, `chip_tool_tests.rs`)

Both examples listen for `Signal::Term` (SIGTERM) to handle graceful shutdown. On Windows, the `async-signal` crate [only supports `Signal::Int`](https://docs.rs/async-signal/latest/async_signal/) (Ctrl+C via `CTRL_C_EVENT`) — `Signal::Term` is never raised by Windows outside of `libc::raise()` and the crate returns an `"unsupported signal"` error when you try to register it.

**Fix:** Use `#[cfg(windows)]` / `#[cfg(unix)]` (or `#[cfg(not(windows))]`) conditional compilation to select the appropriate signal for each platform.

### 2. mDNS network interface selection (`examples/src/common/mdns.rs`)

The `initialize_network()` function selects a network interface that has both an IPv6 **link-local** (`fe80::/10`) address and an IPv4 address. On Windows, the `if_addrs` crate (v0.15.0) may omit link-local IPv6 addresses from its enumeration even when they are present on the adapter (confirmed via `ipconfig` showing `fe80::...%12` while `if_addrs` only returns global IPv6 addresses). This causes the selection to fail with:

```/dev/null/error.txt#L1
Cannot find network interface suitable for mDNS broadcasting
```

**Fix:** Keep the link-local preference as the primary heuristic (it's a good discriminator against virtual interfaces on Linux), but add a fallback that accepts any non-loopback IPv6 address paired with an IPv4 address on the same interface. The shared selection logic is extracted into a closure to avoid duplication.

## Testing

Verified on Windows 11 with an Ethernet adapter. After both fixes, `cargo +nightly run --bin dimmable_light` starts successfully, selects the correct network interface, and begins publishing mDNS services.

Also tested the example itself by adding it to a matter fabric (with IKEA DIRIGERA hub) and sending commands to the example app, which printed that it received them in the log.